### PR TITLE
Fix(course.controller): fixed typo in create course

### DIFF
--- a/app/controllers/course.controller.js
+++ b/app/controllers/course.controller.js
@@ -10,7 +10,7 @@ exports.create = (req, res) => {
   
     // Create a Course
     const course = {
-      courseID = req.params.courseID,
+      courseID: req.params.courseID,
       semesterID: req.body.semesterID,
       name: req.body.name,
       dept: req.body.dept,


### PR DESCRIPTION
Fixed an issue with the course create. missing a : and erased a =